### PR TITLE
Update from upstream

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,4 +1,4 @@
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "1.6.0"
+version = "1.7.0"
 tag_format = "v$version"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.7.0 (2023-04-13)
+
+### Feat
+
+- Allow disabling expensive picture decoding
+
 ## v1.6.0 (2023-01-01)
 
 ### Feat

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "id3"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 authors = [
     "polyfloyd <floyd@polyfloyd.net>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ tokio = { version = "1.21", default-features = false, features = ["rt", "macros"
 tempfile = "3"
 
 [features]
+default = ["decode_picture"]
 
 ## Support parsing ID3 tags with Tokio
 tokio = ["dep:tokio"]
+
+## Picture decoding takes ~20% of time. Allow disabling it if it's unneeded.
+decode_picture = []

--- a/src/stream/tag.rs
+++ b/src/stream/tag.rs
@@ -561,12 +561,14 @@ mod tests {
         assert_eq!(1, tag.disc().unwrap());
         assert_eq!(27, tag.total_discs().unwrap());
         assert_eq!(2015, tag.year().unwrap());
-        assert_eq!(
-            PictureType::Other,
-            tag.pictures().next().unwrap().picture_type
-        );
-        assert_eq!("", tag.pictures().next().unwrap().description);
-        assert_eq!("image/jpeg", tag.pictures().next().unwrap().mime_type);
+        if cfg!(feature = "decode_picture") {
+            assert_eq!(
+                PictureType::Other,
+                tag.pictures().next().unwrap().picture_type
+            );
+            assert_eq!("", tag.pictures().next().unwrap().description);
+            assert_eq!("image/jpeg", tag.pictures().next().unwrap().mime_type);
+        }
     }
 
     #[tokio::test]
@@ -578,12 +580,14 @@ mod tests {
         assert_eq!(1, tag.disc().unwrap());
         assert_eq!(27, tag.total_discs().unwrap());
         assert_eq!(2015, tag.year().unwrap());
-        assert_eq!(
-            PictureType::Other,
-            tag.pictures().next().unwrap().picture_type
-        );
-        assert_eq!("", tag.pictures().next().unwrap().description);
-        assert_eq!("image/jpeg", tag.pictures().next().unwrap().mime_type);
+        if cfg!(feature = "decode_picture") {
+            assert_eq!(
+                PictureType::Other,
+                tag.pictures().next().unwrap().picture_type
+            );
+            assert_eq!("", tag.pictures().next().unwrap().description);
+            assert_eq!("image/jpeg", tag.pictures().next().unwrap().mime_type);
+        }
     }
 
     #[test]
@@ -594,10 +598,12 @@ mod tests {
         assert_eq!("Genre", tag.genre().unwrap());
         assert_eq!(1, tag.disc().unwrap());
         assert_eq!(1, tag.total_discs().unwrap());
-        assert_eq!(
-            PictureType::CoverFront,
-            tag.pictures().next().unwrap().picture_type
-        );
+        if cfg!(feature = "decode_picture") {
+            assert_eq!(
+                PictureType::CoverFront,
+                tag.pictures().next().unwrap().picture_type
+            );
+        }
     }
 
     #[tokio::test]
@@ -608,10 +614,12 @@ mod tests {
         assert_eq!("Genre", tag.genre().unwrap());
         assert_eq!(1, tag.disc().unwrap());
         assert_eq!(1, tag.total_discs().unwrap());
-        assert_eq!(
-            PictureType::CoverFront,
-            tag.pictures().next().unwrap().picture_type
-        );
+        if cfg!(feature = "decode_picture") {
+            assert_eq!(
+                PictureType::CoverFront,
+                tag.pictures().next().unwrap().picture_type
+            );
+        }
     }
 
     #[test]
@@ -694,10 +702,12 @@ mod tests {
         assert_eq!("Title", tag.title().unwrap());
         assert_eq!(1, tag.disc().unwrap());
         assert_eq!(1, tag.total_discs().unwrap());
-        assert_eq!(
-            PictureType::CoverFront,
-            tag.pictures().next().unwrap().picture_type
-        );
+        if cfg!(feature = "decode_picture") {
+            assert_eq!(
+                PictureType::CoverFront,
+                tag.pictures().next().unwrap().picture_type
+            );
+        }
     }
 
     #[test]
@@ -726,6 +736,10 @@ mod tests {
 
     #[test]
     fn write_id3v22() {
+        if !cfg!(feature = "decode_picture") {
+            return;
+        }
+
         let tag = make_tag(Version::Id3v22);
         let mut buffer = Vec::new();
         Encoder::new()
@@ -738,6 +752,10 @@ mod tests {
 
     #[test]
     fn write_id3v22_unsynch() {
+        if !cfg!(feature = "decode_picture") {
+            return;
+        }
+
         let tag = make_tag(Version::Id3v22);
         let mut buffer = Vec::new();
         Encoder::new()
@@ -751,6 +769,10 @@ mod tests {
 
     #[test]
     fn write_id3v22_invalid_id() {
+        if !cfg!(feature = "decode_picture") {
+            return;
+        }
+
         let mut tag = make_tag(Version::Id3v22);
         tag.add_frame(Frame::with_content(
             "XXX",
@@ -784,6 +806,10 @@ mod tests {
 
     #[test]
     fn write_id3v23() {
+        if !cfg!(feature = "decode_picture") {
+            return;
+        }
+
         let tag = make_tag(Version::Id3v23);
         let mut buffer = Vec::new();
         Encoder::new()
@@ -796,6 +822,10 @@ mod tests {
 
     #[test]
     fn write_id3v23_compression() {
+        if !cfg!(feature = "decode_picture") {
+            return;
+        }
+
         let tag = make_tag(Version::Id3v23);
         let mut buffer = Vec::new();
         Encoder::new()
@@ -809,6 +839,10 @@ mod tests {
 
     #[test]
     fn write_id3v23_unsynch() {
+        if !cfg!(feature = "decode_picture") {
+            return;
+        }
+
         let tag = make_tag(Version::Id3v23);
         let mut buffer = Vec::new();
         Encoder::new()
@@ -822,6 +856,10 @@ mod tests {
 
     #[test]
     fn write_id3v24() {
+        if !cfg!(feature = "decode_picture") {
+            return;
+        }
+
         let tag = make_tag(Version::Id3v24);
         let mut buffer = Vec::new();
         Encoder::new()
@@ -834,6 +872,10 @@ mod tests {
 
     #[test]
     fn write_id3v24_compression() {
+        if !cfg!(feature = "decode_picture") {
+            return;
+        }
+
         let tag = make_tag(Version::Id3v24);
         let mut buffer = Vec::new();
         Encoder::new()
@@ -847,6 +889,10 @@ mod tests {
 
     #[test]
     fn write_id3v24_unsynch() {
+        if !cfg!(feature = "decode_picture") {
+            return;
+        }
+
         let tag = make_tag(Version::Id3v24);
         let mut buffer = Vec::new();
         Encoder::new()
@@ -860,6 +906,10 @@ mod tests {
 
     #[test]
     fn write_id3v24_alter_file() {
+        if !cfg!(feature = "decode_picture") {
+            return;
+        }
+
         let mut tag = Tag::new();
         tag.set_duration(1337);
 

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -598,7 +598,9 @@ mod tests {
 
         assert_eq!(tag.title(), Some("Some Great Song"));
         assert_eq!(tag.artist(), Some("Some Great Band"));
-        assert!(tag.pictures().next().is_some())
+        if cfg!(feature = "decode_picture") {
+            assert!(tag.pictures().next().is_some())
+        }
     }
 
     #[test]
@@ -607,7 +609,9 @@ mod tests {
 
         assert_eq!(tag.title(), Some("Some Great Song"));
         assert_eq!(tag.artist(), Some("Some Great Band"));
-        assert!(tag.pictures().next().is_some())
+        if cfg!(feature = "decode_picture") {
+            assert!(tag.pictures().next().is_some())
+        }
     }
 
     #[test]


### PR DESCRIPTION
Merge from upstream:
[feat: Allow disabling expensive picture decoding](https://github.com/steph0de/rust-id3/commit/3a467b154cd53a6a6d03b35fc32af844c5ab5902)
[bump: version 1.6.0 → 1.7.0](https://github.com/steph0de/rust-id3/commit/443a21b43e7083e1b87863cd044e88514187a767)